### PR TITLE
setup.py.in typo

### DIFF
--- a/pypiwheel/setup.py.in
+++ b/pypiwheel/setup.py.in
@@ -35,7 +35,7 @@ class Precompiled(Extension):
 
 
 #pyversion = '=='+str(sys.version_info.major)+'.'+str(sys.version_info.minor)+'.*'
-pyversion = '>=3.7.*'
+pyversion = '>=3.7'
 def main():
 
     setup(


### PR DESCRIPTION
line 38 setup.py.in
pyversion = '>=3.7.*' to
pyversion = '>=3.7'

Docker error message:
[100%] Built target asset
Cleaning asset_asrl install directory
Copied asset_asrl to /asset_asrl/build/pypiwheel/asset_asrl
Copied setup.py to /asset_asrl/build/pypiwheel/asset_asrl
Copied asset.pyd to /asset_asrl/build/pypiwheel/asset_asrl
Generating Binary Wheel
error in asset_asrl setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.7.*'
gmake[2]: *** [pypiwheel/CMakeFiles/pypiwheel.dir/build.make:85: pypiwheel] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:500: pypiwheel/CMakeFiles/pypiwheel.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

