### PR TITLE
Add option to return best iterate from optimizer rather than last

### DIFF
--- a/src/Solvers/PSIOPT.h
+++ b/src/Solvers/PSIOPT.h
@@ -423,6 +423,9 @@ namespace ASSET {
     Eigen::VectorXd LastIqCons;
 
 
+    bool ReturnBest = false;
+    std::string BestCriteria = "ECons";// "ICons,Obj,KKT"
+
 
     /////////////////////////////////////////////////////////////////////
 
@@ -758,7 +761,8 @@ namespace ASSET {
     void print_Beginning(std::string msg) const;
     void print_Finished(std::string msg) const;
     void print_ExitStats(ConvergenceFlags ExitCode,
-                         const std::vector<IterateInfo>& iters,
+                         const IterateInfo & last,
+                         int iternum,
                          double tottime,
                          double nlptime,
                          double qptime);


### PR DESCRIPTION

Added option to return the "best" rather than last iterate from an optimizer run when it does not converge. You can use the constraint/kkt infeasibilities or the objective value as the criteria for determining the best iterate. Defaults to "ECons". Enable it as shown below for phases or ocps.

phase.optimizer.ReturnBest = True  # default is False
phase.optimizer.BestCriteria = “ECons” ## or “ICons”, “KKT”, “Obj”
