### PR TITLE
Numpy 2.0 Compatibility/ Update Pybind11

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "18.1.6"
+          version: "18.1.2"
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -3,14 +3,14 @@ name: pypi-wheels
 
 on:
   workflow_dispatch:
-  
+
 
 
 jobs:
  build_windows:
     env:
       WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/19078/w_BaseKit_p_2023.0.0.25940_offline.exe
-  
+
       WINDOWS_CPP_COMPONENTS: intel.oneapi.win.mkl.devel
       VS_VER: vs2022
       ONEAPI_ROOT: C:/Program Files (x86)/Intel/oneAPI/
@@ -29,14 +29,14 @@ jobs:
     steps:
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "16.0"
-      
+          version: "18.1.6"
+
       - uses: actions/checkout@v3
         with:
           submodules: true
-          
+
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -49,18 +49,18 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Add python requirements
         run: python -m pip install --upgrade wheel setuptools && python -m pip install -r requirements.txt
 
       - name: "Create build directory and run CMake"
-        run: > 
+        run: >
          cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DPIP_INSTALL=True -DBUILD_ASSET_WHEEL=True
-         -DCMAKE_C_COMPILER:FILEPATH="C:/Program Files/LLVM/bin/clang-cl.exe" 
-         -DCMAKE_CXX_COMPILER:FILEPATH="C:/Program Files/LLVM/bin/clang-cl.exe" 
-         -DCMAKE_LINKER:FILEPATH="C:/Program Files/LLVM/bin/lld-link.exe" 
-      
-      - name: "Build Project" 
+         -DCMAKE_C_COMPILER:FILEPATH="C:/Program Files/LLVM/bin/clang-cl.exe"
+         -DCMAKE_CXX_COMPILER:FILEPATH="C:/Program Files/LLVM/bin/clang-cl.exe"
+         -DCMAKE_LINKER:FILEPATH="C:/Program Files/LLVM/bin/lld-link.exe"
+
+      - name: "Build Project"
         run: cmake --build build --target asset pypiwheel --config Release -- -j1
 
       - name: 'Upload Wheels'
@@ -84,12 +84,12 @@ jobs:
           - uses: actions/checkout@v3
             with:
                 submodules: true
-                
+
 
           - uses: actions/setup-python@v3
             with:
               python-version: ${{ matrix.python-version }}
-      
+
           - name: Install Ubuntu dependencies
             env:
                 COMPILER: ${{ matrix.compiler }}
@@ -104,9 +104,9 @@ jobs:
           - name: "Create build directory and run CMake"
             run: cmake -S . -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DPIP_INSTALL=True -DBUILD_ASSET_WHEEL=True
 
-          - name: "Build Project" 
-            run: cmake --build build --target asset pypiwheel --config Release -- -j1 
-      
+          - name: "Build Project"
+            run: cmake --build build --target asset pypiwheel --config Release -- -j1
+
           - name: Audit Wheel Test
             run:  auditwheel show build/pypiwheel/asset_asrl/dist/*.whl
 
@@ -133,12 +133,12 @@ jobs:
           - uses: actions/checkout@v3
             with:
                 submodules: true
-                
+
 
           - uses: actions/setup-python@v3
             with:
               python-version: ${{ matrix.python-version }}
-      
+
           - name: Install Ubuntu dependencies
             env:
                 COMPILER: ${{ matrix.compiler }}
@@ -153,9 +153,9 @@ jobs:
           - name: "Create build directory and run CMake"
             run: cmake -S . -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DPIP_INSTALL=True -DBUILD_ASSET_WHEEL=True
 
-          - name: "Build Project" 
-            run: cmake --build build --target asset pypiwheel --config Release -- -j1 
-      
+          - name: "Build Project"
+            run: cmake --build build --target asset pypiwheel --config Release -- -j1
+
           - name: Audit Wheel Test
             run:  auditwheel show build/pypiwheel/asset_asrl/dist/*.whl
 
@@ -184,7 +184,7 @@ jobs:
         - uses: actions/setup-python@v3
           with:
             python-version: ${{ matrix.python-version }}
-      
+
         - uses: actions/download-artifact@v3
           with:
               path: dists/

--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "18.1.2"
+          version: "17.0"
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Updating pybind11 fixes direct numpy 2.0 compatibility issues. Basemap, which is a dependency for a few python examples appears to still be incompatible. I've submitted an issue on their github.